### PR TITLE
Implement Hapoom RPG spreadsheet simulator

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -1,11 +1,9 @@
-/**
- * Code.gs - Backend logic for Hapoom RPG Spreadsheet Simulator.
- * Handles sheet setup, player lifecycle, event resolution, RNG, and menu bindings.
- */
+// Code.gs - Backend logic for Hapoom RPG Spreadsheet Simulator.
+// Handles sheet setup, player lifecycle, event resolution, RNG, and menu bindings.
 
 // ----------------------------- CONSTANTS ----------------------------------
 const RPG_CONFIG = {
-  menuName: '🎮 Hapoom RPG',
+  menuName: '\uD83C\uDFAE Hapoom RPG',
   menuStartLabel: '게임 시작/계속',
   userPropertyKey: 'HAPOON_RPG_PLAYER_ID',
   adminEmails: ['admin@example.com'], // TODO: Replace with real admin emails.
@@ -119,7 +117,7 @@ function buildSampleEvents() {
       title: '새벽빛 수풀',
       desc: '차가운 새벽 공기 속에서 반짝이는 이슬. 먼 곳에서 작은 울음소리가 들려옵니다.',
       choiceA: { text: '울음소리를 조사한다', effect: { rolls: [ { chance: 0.6, hp: -2, xp: 2, resultText: '숨어 있던 슬라임이 튀어나와 약간의 피해를 입었습니다.' }, { chance: 0.4, gold: 4, resultText: '잃어버린 지갑을 찾았습니다.' } ], flagAdd: ['met_slime'], tagsBoost: ['combat'] } },
-      choiceB: { text: '조용히 명상한다', effect: { hp: +2, xp: 1, resultText: '자연과 호흡하며 체력을 회복했습니다.', next: ['E_SHRINE_WHISPER'] } },
+      choiceB: { text: '조용히 명상한다', effect: { hp: 2, xp: 1, resultText: '자연과 호흡하며 체력을 회복했습니다.', next: ['E_SHRINE_WHISPER'] } },
       choiceC: { text: '길을 급히 떠난다', effect: { xp: 1, resultText: '조심스럽게 발걸음을 옮겼습니다.', next: ['E_ROAD_MERCHANT'], weightShift: { town: 1.2 } } },
       tags: 'opening,forest',
       weight: 5
@@ -138,9 +136,9 @@ function buildSampleEvents() {
       eventId: 'E_TOWN_SHOP',
       title: '작은 노점상',
       desc: '낡은 수레에서 팔을 흔드는 상인.',
-      choiceA: { text: '치유 허브 구매(-4G)', effect: { gold: -4, hp: +4, resultText: '허브 향이 기분 좋게 퍼집니다.', flagAdd: ['met_merchant'] } },
+      choiceA: { text: '치유 허브 구매(-4G)', effect: { gold: -4, hp: 4, resultText: '허브 향이 기분 좋게 퍼집니다.', flagAdd: ['met_merchant'] } },
       choiceB: { text: '정보 교환', effect: { gold: -2, xp: 2, resultText: '상인에게서 귀중한 정보를 들었습니다.', next: ['E_RARE_RELIC'] } },
-      choiceC: { text: '흥정을 시도한다', effect: { rolls: [ { chance: 0.5, gold: +3, resultText: '흥정에 성공해 보너스를 받았습니다!' }, { chance: 0.5, gold: -3, resultText: '흥정 실패! 상인이 화를 냈습니다.' } ], flagAdd: ['met_merchant'] } },
+      choiceC: { text: '흥정을 시도한다', effect: { rolls: [ { chance: 0.5, gold: 3, resultText: '흥정에 성공해 보너스를 받았습니다!' }, { chance: 0.5, gold: -3, resultText: '흥정 실패! 상인이 화를 냈습니다.' } ], flagAdd: ['met_merchant'] } },
       tags: 'town,merchant',
       weight: 6
     },
@@ -149,7 +147,7 @@ function buildSampleEvents() {
       title: '빛나는 유물',
       desc: '모래 속에서 은은한 빛이 새어 나옵니다.',
       choiceA: { text: '유물을 집어 든다', effect: { rolls: [ { chance: 0.5, xp: 5, gold: 6, resultText: '고대 유물이 당신을 인정합니다.' }, { chance: 0.5, hp: -4, resultText: '저주가 발동하여 몸이 얼어붙습니다.' } ], tagsBoost: ['rare'] } },
-      choiceB: { text: '조심스럽게 봉인', effect: { xp: 3, def: +1, resultText: '봉인을 재정비하여 방어력을 높였습니다.' } },
+      choiceB: { text: '조심스럽게 봉인', effect: { xp: 3, def: 1, resultText: '봉인을 재정비하여 방어력을 높였습니다.' } },
       choiceC: { text: '무시하고 간다', effect: { xp: 1, resultText: '무사히 지나쳤습니다.', flagRemove: ['met_merchant'] } },
       tags: 'rare,explore',
       weight: 3
@@ -158,9 +156,9 @@ function buildSampleEvents() {
       eventId: 'E_SHRINE_WHISPER',
       title: '속삭이는 사당',
       desc: '돌기둥 사이로 희미한 빛과 속삭임이 들립니다.',
-      choiceA: { text: '기도한다', effect: { xp: 2, hp: +3, resultText: '따스한 빛이 몸을 감싸 안았습니다.' } },
+      choiceA: { text: '기도한다', effect: { xp: 2, hp: 3, resultText: '따스한 빛이 몸을 감싸 안았습니다.' } },
       choiceB: { text: '공물을 바친다(-3G)', effect: { gold: -3, xp: 4, resultText: '사당이 기뻐하며 힘을 나누어 줍니다.', next: ['E_BLESSING_LIGHT'] } },
-      choiceC: { text: '조사한다', effect: { rolls: [ { chance: 0.4, xp: 5, atk: +1, resultText: '숨겨진 룬을 해독했습니다.' }, { chance: 0.6, hp: -2, resultText: '봉인을 건드려 마력이 새어나왔습니다.' } ] } },
+      choiceC: { text: '조사한다', effect: { rolls: [ { chance: 0.4, xp: 5, atk: 1, resultText: '숨겨진 룬을 해독했습니다.' }, { chance: 0.6, hp: -2, resultText: '봉인을 건드려 마력이 새어나왔습니다.' } ] } },
       tags: 'mystic,rare',
       weight: 4
     },
@@ -168,8 +166,8 @@ function buildSampleEvents() {
       eventId: 'E_ROAD_MERCHANT',
       title: '길 잃은 상단',
       desc: '수레가 넘어져 짐이 흩어져 있습니다.',
-      choiceA: { text: '짐을 도와준다', effect: { xp: 2, gold: +2, resultText: '상인이 보답으로 동전을 줍니다.', flagAdd: ['met_merchant'] } },
-      choiceB: { text: '짐을 슬쩍 챙긴다', effect: { rolls: [ { chance: 0.5, gold: +5, resultText: '아무도 알아차리지 못했습니다.' }, { chance: 0.5, hp: -3, resultText: '상단의 경비에게 붙잡혔습니다!' } ] } },
+      choiceA: { text: '짐을 도와준다', effect: { xp: 2, gold: 2, resultText: '상인이 보답으로 동전을 줍니다.', flagAdd: ['met_merchant'] } },
+      choiceB: { text: '짐을 슬쩍 챙긴다', effect: { rolls: [ { chance: 0.5, gold: 5, resultText: '아무도 알아차리지 못했습니다.' }, { chance: 0.5, hp: -3, resultText: '상단의 경비에게 붙잡혔습니다!' } ] } },
       choiceC: { text: '길 안내만 한다', effect: { xp: 1, resultText: '지도를 설명해 주었습니다.', next: ['E_TOWN_SHOP'] } },
       tags: 'town,common',
       weight: 5
@@ -179,7 +177,7 @@ function buildSampleEvents() {
       title: '고대 함정',
       desc: '발밑에서 바람이 새어나오는 함정 구역.',
       choiceA: { text: '기어가며 통과', effect: { hp: -1, xp: 2, resultText: '몇 번 긁혔지만 지나갔습니다.' } },
-      choiceB: { text: '함정 해체 시도', effect: { rolls: [ { chance: 0.4, gold: +4, xp: 3, resultText: '함정을 해제하고 보물을 챙겼습니다.' }, { chance: 0.6, hp: -4, resultText: '폭발! 큰 피해를 입었습니다.' } ] } },
+      choiceB: { text: '함정 해체 시도', effect: { rolls: [ { chance: 0.4, gold: 4, xp: 3, resultText: '함정을 해제하고 보물을 챙겼습니다.' }, { chance: 0.6, hp: -4, resultText: '폭발! 큰 피해를 입었습니다.' } ] } },
       choiceC: { text: '되돌아간다', effect: { xp: 1, resultText: '안전을 우선시했습니다.', flagRemove: ['trap_warned'] } },
       tags: 'trap,explore',
       weight: 4
@@ -188,9 +186,9 @@ function buildSampleEvents() {
       eventId: 'E_FOREST_SPIRIT',
       title: '숲의 정령',
       desc: '작은 정령이 반짝이며 주변을 맴돕니다.',
-      choiceA: { text: '손을 내민다', effect: { rolls: [ { chance: 0.5, hp: +5, resultText: '정령이 치유의 힘을 나눠줍니다.' }, { chance: 0.5, hp: -3, resultText: '정령이 장난을 쳐 체력이 빠졌습니다.' } ] } },
+      choiceA: { text: '손을 내민다', effect: { rolls: [ { chance: 0.5, hp: 5, resultText: '정령이 치유의 힘을 나눠줍니다.' }, { chance: 0.5, hp: -3, resultText: '정령이 장난을 쳐 체력이 빠졌습니다.' } ] } },
       choiceB: { text: '정령과 거래', effect: { gold: -2, xp: 3, resultText: '정령이 소원을 들어주었습니다.', flagAdd: ['spirit_friend'] } },
-      choiceC: { text: '정령을 포획', effect: { hp: -2, atk: +1, resultText: '정령의 힘을 장비에 봉인했습니다.', flagRemove: ['spirit_friend'] } },
+      choiceC: { text: '정령을 포획', effect: { hp: -2, atk: 1, resultText: '정령의 힘을 장비에 봉인했습니다.', flagRemove: ['spirit_friend'] } },
       tags: 'mystic,rare',
       weight: 3
     },
@@ -198,8 +196,8 @@ function buildSampleEvents() {
       eventId: 'E_BLESSING_LIGHT',
       title: '빛의 가호',
       desc: '사당에서 받아온 부적이 따스하게 빛납니다.',
-      choiceA: { text: '부적을 사용한다', effect: { hp: +6, xp: 2, resultText: '심장이 강하게 뛰며 힘이 솟습니다.', flagRemove: ['met_merchant'] } },
-      choiceB: { text: '부적을 팔아버린다', effect: { gold: +6, resultText: '상인에게 고가에 팔았습니다.' } },
+      choiceA: { text: '부적을 사용한다', effect: { hp: 6, xp: 2, resultText: '심장이 강하게 뛰며 힘이 솟습니다.', flagRemove: ['met_merchant'] } },
+      choiceB: { text: '부적을 팔아버린다', effect: { gold: 6, resultText: '상인에게 고가에 팔았습니다.' } },
       choiceC: { text: '선물을 나눈다', effect: { gold: -2, xp: 3, resultText: '빛을 나누며 명성을 얻었습니다.', flagAdd: ['blessed'] } },
       tags: 'rare,town',
       weight: 2
@@ -209,7 +207,7 @@ function buildSampleEvents() {
       title: '밤의 습격',
       desc: '어둠 속에서 그림자가 달려듭니다.',
       choiceA: { text: '즉각 반격', effect: { rolls: [ { chance: 0.6, xp: 4, gold: 3, resultText: '습격자를 제압했습니다.' }, { chance: 0.4, hp: -5, resultText: '기습을 막지 못했습니다.' } ], tagsBoost: ['combat'] } },
-      choiceB: { text: '방패를 들고 버틴다', effect: { hp: -2, def: +1, resultText: '피해는 있었지만 방어를 익혔습니다.' } },
+      choiceB: { text: '방패를 들고 버틴다', effect: { hp: -2, def: 1, resultText: '피해는 있었지만 방어를 익혔습니다.' } },
       choiceC: { text: '연막탄으로 탈출', effect: { gold: -1, xp: 2, resultText: '연막을 치고 빠져나왔습니다.' } },
       tags: 'combat,trap',
       weight: 5
@@ -218,7 +216,7 @@ function buildSampleEvents() {
       eventId: 'E_LOST_CHILD',
       title: '길 잃은 아이',
       desc: '울고 있는 아이가 길모퉁이에 앉아 있습니다.',
-      choiceA: { text: '집으로 데려다준다', effect: { xp: 3, gold: +2, resultText: '가족이 감사의 선물을 주었습니다.', flagAdd: ['town_ally'] } },
+      choiceA: { text: '집으로 데려다준다', effect: { xp: 3, gold: 2, resultText: '가족이 감사의 선물을 주었습니다.', flagAdd: ['town_ally'] } },
       choiceB: { text: '용기를 북돋운다', effect: { xp: 2, resultText: '아이에게 용기를 심어주었습니다.' } },
       choiceC: { text: '무시한다', effect: { resultText: '뒤돌아보지 않았습니다.', flagRemove: ['town_ally'] } },
       tags: 'town,story',

--- a/Code.gs
+++ b/Code.gs
@@ -1,0 +1,845 @@
+/**
+ * Code.gs - Backend logic for Hapoom RPG Spreadsheet Simulator.
+ * Handles sheet setup, player lifecycle, event resolution, RNG, and menu bindings.
+ */
+
+// ----------------------------- CONSTANTS ----------------------------------
+const RPG_CONFIG = {
+  menuName: '🎮 Hapoom RPG',
+  menuStartLabel: '게임 시작/계속',
+  userPropertyKey: 'HAPOON_RPG_PLAYER_ID',
+  adminEmails: ['admin@example.com'], // TODO: Replace with real admin emails.
+  xpBase: 12,
+  xpGrowth: 6,
+  levelHpBonus: 4,
+  levelAtkBonus: 1,
+  levelDefBonus: 1,
+  healOnLevelUpRatio: 0.4,
+  queueMax: 5
+};
+
+const SHEET_NAMES = {
+  players: 'Players',
+  events: 'Events',
+  log: 'Log',
+  assets: 'Assets'
+};
+
+const PLAYER_HEADERS = ['playerId', 'name', 'cls', 'hp', 'maxHp', 'gold', 'atk', 'def', 'level', 'xp', 'seed', 'createdAt', 'lastPlayedAt', 'state'];
+const EVENT_HEADERS = ['eventId', 'title', 'desc', 'choiceA_text', 'choiceA_effect', 'choiceB_text', 'choiceB_effect', 'choiceC_text', 'choiceC_effect', 'tags', 'weight'];
+const LOG_HEADERS = ['timestamp', 'playerId', 'eventId', 'choice', 'delta', 'resultText'];
+const ASSET_HEADERS = ['key', 'type', 'value'];
+
+const CLASS_PRESETS = [
+  { key: 'wanderer', name: '방랑자', hp: 12, atk: 3, def: 1, desc: '균형 잡힌 모험가' },
+  { key: 'sentinel', name: '수호자', hp: 16, atk: 2, def: 3, desc: '튼튼한 방패의 달인' },
+  { key: 'mystic', name: '비전술사', hp: 10, atk: 4, def: 1, desc: '마력을 다루는 학자' }
+];
+
+// ------------------------------- MENU --------------------------------------
+function onOpen() {
+  SpreadsheetApp.getUi()
+    .createMenu(RPG_CONFIG.menuName)
+    .addItem(RPG_CONFIG.menuStartLabel, 'showGameSidebar')
+    .addToUi();
+}
+
+function showGameSidebar() {
+  const html = HtmlService.createTemplateFromFile('ui');
+  html.data = {
+    version: new Date().getTime()
+  };
+  const output = html.evaluate();
+  output.setTitle('Hapoom RPG');
+  output.setSandboxMode(HtmlService.SandboxMode.IFRAME);
+  SpreadsheetApp.getUi().showSidebar(output);
+}
+
+// ---------------------------- SHEET SETUP ----------------------------------
+function setupSheets() {
+  const ss = SpreadsheetApp.getActive();
+  const playersSheet = getOrCreateSheet(ss, SHEET_NAMES.players, PLAYER_HEADERS);
+  const eventsSheet = getOrCreateSheet(ss, SHEET_NAMES.events, EVENT_HEADERS);
+  const logSheet = getOrCreateSheet(ss, SHEET_NAMES.log, LOG_HEADERS);
+  const assetsSheet = getOrCreateSheet(ss, SHEET_NAMES.assets, ASSET_HEADERS);
+
+  // Clear existing data (preserve headers)
+  clearSheetExceptHeader(playersSheet);
+  clearSheetExceptHeader(eventsSheet);
+  clearSheetExceptHeader(logSheet);
+  clearSheetExceptHeader(assetsSheet);
+
+  // Insert sample assets including palette, sprites, and localization seeds.
+  const assets = [
+    ['pal_background', 'color', '#0d0f1a'],
+    ['pal_accent', 'color', '#7DF9FF'],
+    ['pal_positive', 'color', '#A7F3D0'],
+    ['pal_negative', 'color', '#FCA5A5'],
+    ['sprite_hero', 'css', '<div class="px-sprite hero"></div>'],
+    ['sprite_slime', 'css', '<div class="px-sprite slime"></div>'],
+    ['sprite_treasure', 'css', '<div class="px-sprite treasure"></div>'],
+    ['sprite_mystic', 'css', '<div class="px-sprite mystic"></div>'],
+    ['text_start_button', 'string', '모험 시작'],
+    ['text_continue_button', 'string', '계속'],
+    ['text_hp', 'string', 'HP'],
+    ['text_gold', 'string', 'Gold'],
+    ['text_xp', 'string', 'XP'],
+    ['text_level', 'string', 'Lv.'],
+    ['i18n_note', 'note', '문자열 키를 Assets 시트에서 언어별로 확장 가능 (예: text_start_button_ko/en)']
+  ];
+  assetsSheet.getRange(2, 1, assets.length, ASSET_HEADERS.length).setValues(assets);
+
+  // Insert sample events (10+ entries) with varied tags and weights.
+  const sampleEvents = buildSampleEvents();
+  eventsSheet.getRange(2, 1, sampleEvents.length, EVENT_HEADERS.length).setValues(sampleEvents);
+}
+
+function getOrCreateSheet(ss, name, headers) {
+  let sheet = ss.getSheetByName(name);
+  if (!sheet) {
+    sheet = ss.insertSheet(name);
+  }
+  sheet.clear();
+  sheet.appendRow(headers);
+  return sheet;
+}
+
+function clearSheetExceptHeader(sheet) {
+  const lastRow = sheet.getLastRow();
+  if (lastRow > 1) {
+    sheet.getRange(2, 1, lastRow - 1, sheet.getLastColumn()).clearContent();
+  }
+}
+
+// Builds array rows for the Events sheet. Include Events expansion guide in comments.
+function buildSampleEvents() {
+  const events = [
+    {
+      eventId: 'E_START_GLADE',
+      title: '새벽빛 수풀',
+      desc: '차가운 새벽 공기 속에서 반짝이는 이슬. 먼 곳에서 작은 울음소리가 들려옵니다.',
+      choiceA: { text: '울음소리를 조사한다', effect: { rolls: [ { chance: 0.6, hp: -2, xp: 2, resultText: '숨어 있던 슬라임이 튀어나와 약간의 피해를 입었습니다.' }, { chance: 0.4, gold: 4, resultText: '잃어버린 지갑을 찾았습니다.' } ], flagAdd: ['met_slime'], tagsBoost: ['combat'] } },
+      choiceB: { text: '조용히 명상한다', effect: { hp: +2, xp: 1, resultText: '자연과 호흡하며 체력을 회복했습니다.', next: ['E_SHRINE_WHISPER'] } },
+      choiceC: { text: '길을 급히 떠난다', effect: { xp: 1, resultText: '조심스럽게 발걸음을 옮겼습니다.', next: ['E_ROAD_MERCHANT'], weightShift: { town: 1.2 } } },
+      tags: 'opening,forest',
+      weight: 5
+    },
+    {
+      eventId: 'E_MON_SLIME',
+      title: '슬라임 습격',
+      desc: '포들포들한 슬라임이 길을 막았습니다.',
+      choiceA: { text: '찌르기 공격', effect: { hp: -1, xp: 3, resultText: '슬라임을 갈랐습니다! 끈적한 흔적만 남네요.', gold: 3, tagsBoost: ['combat'] } },
+      choiceB: { text: '분석 후 약점 노리기', effect: { rolls: [ { chance: 0.7, xp: 4, gold: 2, resultText: '약점을 찾아내 큰 피해를 주었습니다.' }, { chance: 0.3, hp: -3, resultText: '분석하다가 슬라임이 덮쳤습니다!' } ] } },
+      choiceC: { text: '후퇴한다', effect: { hp: -1, resultText: '후퇴하는 동안 슬라임이 튀어 올랐습니다.', flagRemove: ['met_slime'] } },
+      tags: 'combat,common',
+      weight: 8
+    },
+    {
+      eventId: 'E_TOWN_SHOP',
+      title: '작은 노점상',
+      desc: '낡은 수레에서 팔을 흔드는 상인.',
+      choiceA: { text: '치유 허브 구매(-4G)', effect: { gold: -4, hp: +4, resultText: '허브 향이 기분 좋게 퍼집니다.', flagAdd: ['met_merchant'] } },
+      choiceB: { text: '정보 교환', effect: { gold: -2, xp: 2, resultText: '상인에게서 귀중한 정보를 들었습니다.', next: ['E_RARE_RELIC'] } },
+      choiceC: { text: '흥정을 시도한다', effect: { rolls: [ { chance: 0.5, gold: +3, resultText: '흥정에 성공해 보너스를 받았습니다!' }, { chance: 0.5, gold: -3, resultText: '흥정 실패! 상인이 화를 냈습니다.' } ], flagAdd: ['met_merchant'] } },
+      tags: 'town,merchant',
+      weight: 6
+    },
+    {
+      eventId: 'E_RARE_RELIC',
+      title: '빛나는 유물',
+      desc: '모래 속에서 은은한 빛이 새어 나옵니다.',
+      choiceA: { text: '유물을 집어 든다', effect: { rolls: [ { chance: 0.5, xp: 5, gold: 6, resultText: '고대 유물이 당신을 인정합니다.' }, { chance: 0.5, hp: -4, resultText: '저주가 발동하여 몸이 얼어붙습니다.' } ], tagsBoost: ['rare'] } },
+      choiceB: { text: '조심스럽게 봉인', effect: { xp: 3, def: +1, resultText: '봉인을 재정비하여 방어력을 높였습니다.' } },
+      choiceC: { text: '무시하고 간다', effect: { xp: 1, resultText: '무사히 지나쳤습니다.', flagRemove: ['met_merchant'] } },
+      tags: 'rare,explore',
+      weight: 3
+    },
+    {
+      eventId: 'E_SHRINE_WHISPER',
+      title: '속삭이는 사당',
+      desc: '돌기둥 사이로 희미한 빛과 속삭임이 들립니다.',
+      choiceA: { text: '기도한다', effect: { xp: 2, hp: +3, resultText: '따스한 빛이 몸을 감싸 안았습니다.' } },
+      choiceB: { text: '공물을 바친다(-3G)', effect: { gold: -3, xp: 4, resultText: '사당이 기뻐하며 힘을 나누어 줍니다.', next: ['E_BLESSING_LIGHT'] } },
+      choiceC: { text: '조사한다', effect: { rolls: [ { chance: 0.4, xp: 5, atk: +1, resultText: '숨겨진 룬을 해독했습니다.' }, { chance: 0.6, hp: -2, resultText: '봉인을 건드려 마력이 새어나왔습니다.' } ] } },
+      tags: 'mystic,rare',
+      weight: 4
+    },
+    {
+      eventId: 'E_ROAD_MERCHANT',
+      title: '길 잃은 상단',
+      desc: '수레가 넘어져 짐이 흩어져 있습니다.',
+      choiceA: { text: '짐을 도와준다', effect: { xp: 2, gold: +2, resultText: '상인이 보답으로 동전을 줍니다.', flagAdd: ['met_merchant'] } },
+      choiceB: { text: '짐을 슬쩍 챙긴다', effect: { rolls: [ { chance: 0.5, gold: +5, resultText: '아무도 알아차리지 못했습니다.' }, { chance: 0.5, hp: -3, resultText: '상단의 경비에게 붙잡혔습니다!' } ] } },
+      choiceC: { text: '길 안내만 한다', effect: { xp: 1, resultText: '지도를 설명해 주었습니다.', next: ['E_TOWN_SHOP'] } },
+      tags: 'town,common',
+      weight: 5
+    },
+    {
+      eventId: 'E_ANCIENT_TRAP',
+      title: '고대 함정',
+      desc: '발밑에서 바람이 새어나오는 함정 구역.',
+      choiceA: { text: '기어가며 통과', effect: { hp: -1, xp: 2, resultText: '몇 번 긁혔지만 지나갔습니다.' } },
+      choiceB: { text: '함정 해체 시도', effect: { rolls: [ { chance: 0.4, gold: +4, xp: 3, resultText: '함정을 해제하고 보물을 챙겼습니다.' }, { chance: 0.6, hp: -4, resultText: '폭발! 큰 피해를 입었습니다.' } ] } },
+      choiceC: { text: '되돌아간다', effect: { xp: 1, resultText: '안전을 우선시했습니다.', flagRemove: ['trap_warned'] } },
+      tags: 'trap,explore',
+      weight: 4
+    },
+    {
+      eventId: 'E_FOREST_SPIRIT',
+      title: '숲의 정령',
+      desc: '작은 정령이 반짝이며 주변을 맴돕니다.',
+      choiceA: { text: '손을 내민다', effect: { rolls: [ { chance: 0.5, hp: +5, resultText: '정령이 치유의 힘을 나눠줍니다.' }, { chance: 0.5, hp: -3, resultText: '정령이 장난을 쳐 체력이 빠졌습니다.' } ] } },
+      choiceB: { text: '정령과 거래', effect: { gold: -2, xp: 3, resultText: '정령이 소원을 들어주었습니다.', flagAdd: ['spirit_friend'] } },
+      choiceC: { text: '정령을 포획', effect: { hp: -2, atk: +1, resultText: '정령의 힘을 장비에 봉인했습니다.', flagRemove: ['spirit_friend'] } },
+      tags: 'mystic,rare',
+      weight: 3
+    },
+    {
+      eventId: 'E_BLESSING_LIGHT',
+      title: '빛의 가호',
+      desc: '사당에서 받아온 부적이 따스하게 빛납니다.',
+      choiceA: { text: '부적을 사용한다', effect: { hp: +6, xp: 2, resultText: '심장이 강하게 뛰며 힘이 솟습니다.', flagRemove: ['met_merchant'] } },
+      choiceB: { text: '부적을 팔아버린다', effect: { gold: +6, resultText: '상인에게 고가에 팔았습니다.' } },
+      choiceC: { text: '선물을 나눈다', effect: { gold: -2, xp: 3, resultText: '빛을 나누며 명성을 얻었습니다.', flagAdd: ['blessed'] } },
+      tags: 'rare,town',
+      weight: 2
+    },
+    {
+      eventId: 'E_NIGHT_AMBUSH',
+      title: '밤의 습격',
+      desc: '어둠 속에서 그림자가 달려듭니다.',
+      choiceA: { text: '즉각 반격', effect: { rolls: [ { chance: 0.6, xp: 4, gold: 3, resultText: '습격자를 제압했습니다.' }, { chance: 0.4, hp: -5, resultText: '기습을 막지 못했습니다.' } ], tagsBoost: ['combat'] } },
+      choiceB: { text: '방패를 들고 버틴다', effect: { hp: -2, def: +1, resultText: '피해는 있었지만 방어를 익혔습니다.' } },
+      choiceC: { text: '연막탄으로 탈출', effect: { gold: -1, xp: 2, resultText: '연막을 치고 빠져나왔습니다.' } },
+      tags: 'combat,trap',
+      weight: 5
+    },
+    {
+      eventId: 'E_LOST_CHILD',
+      title: '길 잃은 아이',
+      desc: '울고 있는 아이가 길모퉁이에 앉아 있습니다.',
+      choiceA: { text: '집으로 데려다준다', effect: { xp: 3, gold: +2, resultText: '가족이 감사의 선물을 주었습니다.', flagAdd: ['town_ally'] } },
+      choiceB: { text: '용기를 북돋운다', effect: { xp: 2, resultText: '아이에게 용기를 심어주었습니다.' } },
+      choiceC: { text: '무시한다', effect: { resultText: '뒤돌아보지 않았습니다.', flagRemove: ['town_ally'] } },
+      tags: 'town,story',
+      weight: 4
+    }
+  ];
+
+  // Events 확장 가이드: 새로운 이벤트는 EVENT_HEADERS 순서를 지키고, effect JSON에 hp/gold/xp/atk/def/next/flagAdd/flagRemove/rolls/resultText 등을 조합해 서사를 구성합니다.
+  return events.map(function (evt) {
+    return [
+      evt.eventId,
+      evt.title,
+      evt.desc,
+      evt.choiceA.text,
+      JSON.stringify(evt.choiceA.effect),
+      evt.choiceB.text,
+      JSON.stringify(evt.choiceB.effect),
+      evt.choiceC.text,
+      JSON.stringify(evt.choiceC.effect),
+      evt.tags,
+      evt.weight
+    ];
+  });
+}
+
+// ---------------------------- GAME SERVICES --------------------------------
+function loadGame() {
+  const context = buildContext();
+  const playerRecord = getCurrentPlayerRecord(context);
+  if (!playerRecord) {
+    return {
+      needsCreation: true,
+      classes: CLASS_PRESETS,
+      assets: context.assets,
+      version: context.version,
+      debug: context.debug
+    };
+  }
+
+  const player = playerRecord.player;
+  let state = playerRecord.state;
+  if (!state.queue) state.queue = [];
+  if (!state.flags) state.flags = [];
+  if (!state.currentEventId) {
+    state.currentEventId = drawNextEvent(player, state, context);
+  }
+
+  const currentEvent = getEventById(context.events, state.currentEventId);
+  if (!currentEvent) {
+    state.currentEventId = drawNextEvent(player, state, context);
+  }
+
+  // Persist state if mutated during load.
+  savePlayerState(player, state, context);
+
+  return {
+    needsCreation: false,
+    player: sanitizePlayerForClient(player),
+    state: filterStateForClient(state),
+    event: currentEvent,
+    assets: context.assets,
+    queueSize: state.queue.length,
+    debug: context.debug,
+    logs: getRecentLogs(player.playerId, 10)
+  };
+}
+
+function startNewPlayer(payload) {
+  const context = buildContext();
+  const name = (payload && payload.name) ? payload.name.trim() : '';
+  const clsKey = payload && payload.clsKey;
+  if (!name) throw new Error('이름을 입력해주세요.');
+  const preset = CLASS_PRESETS.find(function (c) { return c.key === clsKey; });
+  if (!preset) throw new Error('잘못된 직업입니다.');
+
+  const ss = SpreadsheetApp.getActive();
+  const playersSheet = ss.getSheetByName(SHEET_NAMES.players);
+
+  const playerId = 'P_' + Utilities.getUuid();
+  const now = new Date();
+  const seed = Utilities.getUuid();
+  const initialState = {
+    queue: [],
+    flags: [],
+    currentEventId: null,
+    lastChoice: null,
+    isDead: false
+  };
+  const row = [
+    playerId,
+    name,
+    preset.name,
+    preset.hp,
+    preset.hp,
+    6,
+    preset.atk,
+    preset.def,
+    1,
+    0,
+    seed,
+    now,
+    now,
+    JSON.stringify(initialState)
+  ];
+  playersSheet.appendRow(row);
+
+  PropertiesService.getUserProperties().setProperty(RPG_CONFIG.userPropertyKey, playerId);
+
+  return loadGame();
+}
+
+function chooseOption(choicePayload) {
+  const context = buildContext();
+  const playerRecord = getCurrentPlayerRecord(context);
+  if (!playerRecord) {
+    throw new Error('플레이어가 없습니다. 새로 생성해주세요.');
+  }
+  const player = playerRecord.player;
+  const state = playerRecord.state;
+  if (state.isDead) {
+    throw new Error('이미 패배한 세션입니다. 새로 시작해주세요.');
+  }
+
+  const choiceKey = (choicePayload && choicePayload.choice) || 'A';
+  const eventId = state.currentEventId;
+  const event = getEventById(context.events, eventId);
+  if (!event) {
+    state.currentEventId = drawNextEvent(player, state, context);
+    savePlayerState(player, state, context);
+    throw new Error('이벤트를 찾을 수 없어 다음 이벤트로 이동합니다.');
+  }
+
+  const effect = getEffectForChoice(event, choiceKey);
+  if (!effect) {
+    throw new Error('잘못된 선택입니다.');
+  }
+
+  const resolution = resolveEffect(effect, player, state, context, choiceKey, event);
+  applyDeltaToPlayer(player, resolution.delta);
+  const levelUpInfo = applyLevelUpIfNeeded(player, resolution);
+  applyFlags(state, resolution.flags);
+  enqueueNextEvents(state, resolution.nextQueue);
+
+  const timestamp = new Date();
+  const death = player.hp <= 0;
+  if (death) {
+    state.isDead = true;
+    resolution.messages.push('당신은 쓰러졌습니다.');
+    player.hp = 0;
+  }
+
+  state.lastChoice = { eventId: event.eventId, choice: choiceKey, at: timestamp };
+  if (!death) {
+    state.currentEventId = drawNextEvent(player, state, context);
+  } else {
+    state.currentEventId = null;
+  }
+
+  player.lastPlayedAt = timestamp;
+  savePlayerState(player, state, context);
+  appendLogEntry(timestamp, player.playerId, event.eventId, choiceKey, resolution.delta, resolution.messages.join(' '));
+
+  return {
+    player: sanitizePlayerForClient(player),
+    state: filterStateForClient(state),
+    event: death ? null : getEventById(context.events, state.currentEventId),
+    result: {
+      messages: resolution.messages,
+      delta: resolution.delta,
+      levelUps: levelUpInfo.levelUps,
+      healedOnLevel: levelUpInfo.healed,
+      death: death
+    },
+    queueSize: state.queue.length,
+    logs: getRecentLogs(player.playerId, 10)
+  };
+}
+
+function resetPlayerSession() {
+  const userProps = PropertiesService.getUserProperties();
+  userProps.deleteProperty(RPG_CONFIG.userPropertyKey);
+  return loadGame();
+}
+
+// --------------------------- DEBUG UTILITIES --------------------------------
+function toggleDebugAction(action, value) {
+  const context = buildContext();
+  if (!context.debug.isAdmin) {
+    throw new Error('권한이 없습니다.');
+  }
+  const record = getCurrentPlayerRecord(context);
+  if (!record) {
+    throw new Error('플레이어가 없습니다.');
+  }
+  const player = record.player;
+  const state = record.state;
+  if (action === 'forceEvent') {
+    enqueueNextEvents(state, [{ eventId: value, priority: true }]);
+    if (!state.currentEventId) {
+      state.currentEventId = drawNextEvent(player, state, context);
+    }
+  } else if (action === 'heal') {
+    const healAmount = Math.ceil(player.maxHp * 0.5);
+    player.hp = Math.min(player.maxHp, player.hp + healAmount);
+  }
+  savePlayerState(player, state, context);
+  return {
+    player: sanitizePlayerForClient(player),
+    state: filterStateForClient(state),
+    event: state.currentEventId ? getEventById(context.events, state.currentEventId) : null,
+    queueSize: state.queue.length
+  };
+}
+
+// -------------------------- INTERNAL HELPERS --------------------------------
+function buildContext() {
+  const ss = SpreadsheetApp.getActive();
+  const assets = loadAssets(ss.getSheetByName(SHEET_NAMES.assets));
+  const events = loadEvents(ss.getSheetByName(SHEET_NAMES.events));
+  const userEmail = Session.getActiveUser().getEmail();
+  const isAdmin = !!userEmail && RPG_CONFIG.adminEmails.indexOf(userEmail) !== -1;
+  return {
+    ss: ss,
+    assets: assets,
+    events: events,
+    userEmail: userEmail,
+    debug: { isAdmin: isAdmin },
+    version: new Date().getTime()
+  };
+}
+
+function getCurrentPlayerRecord(context) {
+  const playerId = PropertiesService.getUserProperties().getProperty(RPG_CONFIG.userPropertyKey);
+  if (!playerId) return null;
+  const playersSheet = context.ss.getSheetByName(SHEET_NAMES.players);
+  const data = playersSheet.getDataRange().getValues();
+  const headers = data.shift();
+  const idx = headers.reduce(function (acc, header, i) { acc[header] = i; return acc; }, {});
+  for (var i = 0; i < data.length; i++) {
+    if (data[i][idx.playerId] === playerId) {
+      const row = data[i];
+      const player = {
+        rowIndex: i + 2,
+        playerId: row[idx.playerId],
+        name: row[idx.name],
+        cls: row[idx.cls],
+        hp: Number(row[idx.hp]) || 0,
+        maxHp: Number(row[idx.maxHp]) || 0,
+        gold: Number(row[idx.gold]) || 0,
+        atk: Number(row[idx.atk]) || 0,
+        def: Number(row[idx.def]) || 0,
+        level: Number(row[idx.level]) || 1,
+        xp: Number(row[idx.xp]) || 0,
+        seed: row[idx.seed] || Utilities.getUuid(),
+        createdAt: row[idx.createdAt],
+        lastPlayedAt: row[idx.lastPlayedAt]
+      };
+      let state = {};
+      try {
+        state = JSON.parse(row[idx.state] || '{}');
+      } catch (e) {
+        state = {};
+      }
+      return { player: player, state: state };
+    }
+  }
+  return null;
+}
+
+function sanitizePlayerForClient(player) {
+  return {
+    playerId: player.playerId,
+    name: player.name,
+    cls: player.cls,
+    hp: player.hp,
+    maxHp: player.maxHp,
+    gold: player.gold,
+    atk: player.atk,
+    def: player.def,
+    level: player.level,
+    xp: player.xp
+  };
+}
+
+function filterStateForClient(state) {
+  return {
+    flags: state.flags || [],
+    queueCount: (state.queue || []).length,
+    lastChoice: state.lastChoice,
+    isDead: !!state.isDead
+  };
+}
+
+function loadAssets(sheet) {
+  if (!sheet) return {};
+  const values = sheet.getDataRange().getValues();
+  values.shift();
+  const map = {};
+  values.forEach(function (row) {
+    if (row[0]) map[row[0]] = { type: row[1], value: row[2] };
+  });
+  return map;
+}
+
+function loadEvents(sheet) {
+  if (!sheet) return [];
+  const values = sheet.getDataRange().getValues();
+  const headers = values.shift();
+  const idx = headers.reduce(function (acc, header, i) { acc[header] = i; return acc; }, {});
+  return values.filter(function (row) { return row[idx.eventId]; }).map(function (row) {
+    return {
+      eventId: row[idx.eventId],
+      title: row[idx.title],
+      desc: row[idx.desc],
+      tags: (row[idx.tags] || '').split(',').map(function (t) { return t.trim(); }).filter(Boolean),
+      weight: Number(row[idx.weight]) || 1,
+      choices: {
+        A: { text: row[idx.choiceA_text], effect: parseJsonSafe(row[idx.choiceA_effect]) },
+        B: { text: row[idx.choiceB_text], effect: parseJsonSafe(row[idx.choiceB_effect]) },
+        C: { text: row[idx.choiceC_text], effect: parseJsonSafe(row[idx.choiceC_effect]) }
+      }
+    };
+  });
+}
+
+function parseJsonSafe(value) {
+  if (!value) return {};
+  try {
+    return JSON.parse(value);
+  } catch (e) {
+    return {};
+  }
+}
+
+function getEventById(events, eventId) {
+  if (!eventId) return null;
+  for (var i = 0; i < events.length; i++) {
+    if (events[i].eventId === eventId) return events[i];
+  }
+  return null;
+}
+
+function getEffectForChoice(event, choiceKey) {
+  const upper = String(choiceKey || 'A').toUpperCase();
+  return (event.choices[upper] && event.choices[upper].effect) || null;
+}
+
+function resolveEffect(effect, player, state, context, choiceKey, event) {
+  const rollEffect = mergeEffectWithRoll(effect, player, state, context, choiceKey, event);
+  const delta = {};
+  const flags = { add: [], remove: [] };
+  const nextQueue = [];
+  const messages = [];
+
+  const statKeys = ['hp', 'gold', 'xp', 'atk', 'def', 'maxHp'];
+  statKeys.forEach(function (key) {
+    if (typeof rollEffect[key] === 'number') {
+      delta[key] = (delta[key] || 0) + rollEffect[key];
+    }
+  });
+
+  if (Array.isArray(rollEffect.next)) {
+    rollEffect.next.forEach(function (eventId) {
+      nextQueue.push({ eventId: eventId, priority: true });
+    });
+  }
+  if (Array.isArray(rollEffect.queue)) {
+    rollEffect.queue.forEach(function (eventId) {
+      nextQueue.push({ eventId: eventId, priority: false });
+    });
+  }
+  if (Array.isArray(rollEffect.flagAdd)) {
+    flags.add = flags.add.concat(rollEffect.flagAdd);
+  }
+  if (Array.isArray(rollEffect.flagRemove)) {
+    flags.remove = flags.remove.concat(rollEffect.flagRemove);
+  }
+  if (rollEffect.weightShift) {
+    state.weightShift = state.weightShift || {};
+    Object.keys(rollEffect.weightShift).forEach(function (tag) {
+      const current = Number(state.weightShift[tag]) || 1;
+      state.weightShift[tag] = current * Number(rollEffect.weightShift[tag]);
+    });
+  }
+  if (Array.isArray(rollEffect.tagsBoost)) {
+    state.tagsBoost = state.tagsBoost || {};
+    rollEffect.tagsBoost.forEach(function (tag) {
+      const current = Number(state.tagsBoost[tag]) || 1;
+      state.tagsBoost[tag] = current + 0.2;
+    });
+  }
+
+  if (rollEffect.resultText) {
+    messages.push(rollEffect.resultText);
+  }
+
+  return { delta: delta, flags: flags, nextQueue: nextQueue, messages: messages, effectMeta: rollEffect };
+}
+
+function mergeEffectWithRoll(effect, player, state, context, choiceKey, event) {
+  const merged = Object.assign({}, effect);
+  if (Array.isArray(effect.rolls) && effect.rolls.length) {
+    const rng = pseudoRandom(player.seed + (state.lastChoice ? state.lastChoice.eventId : '') + choiceKey + event.eventId + new Date().getTime());
+    let cumulative = 0;
+    let selected = effect.rolls[effect.rolls.length - 1];
+    effect.rolls.forEach(function (roll) {
+      cumulative += Number(roll.chance) || 0;
+      if (selected === effect.rolls[effect.rolls.length - 1] && rng <= cumulative) {
+        selected = roll;
+      }
+    });
+    Object.keys(selected).forEach(function (key) {
+      if (key !== 'chance') {
+        merged[key] = selected[key];
+      }
+    });
+  }
+  delete merged.rolls;
+  return merged;
+}
+
+function pseudoRandom(seed) {
+  const str = String(seed) + Utilities.getUuid();
+  var hash = 0;
+  for (var i = 0; i < str.length; i++) {
+    hash = ((hash << 5) - hash) + str.charCodeAt(i);
+    hash |= 0;
+  }
+  return Math.abs(hash % 10000) / 10000;
+}
+
+function applyDeltaToPlayer(player, delta) {
+  Object.keys(delta).forEach(function (key) {
+    if (typeof delta[key] === 'number') {
+      player[key] = (player[key] || 0) + delta[key];
+    }
+  });
+  if (player.gold < 0) player.gold = 0;
+  if (player.hp > player.maxHp) player.hp = player.maxHp;
+}
+
+function applyLevelUpIfNeeded(player, resolution) {
+  let healed = 0;
+  const levelUps = [];
+  let xpNeeded = xpForNextLevel(player.level);
+  while (player.xp >= xpNeeded) {
+    player.xp -= xpNeeded;
+    player.level += 1;
+    player.maxHp += RPG_CONFIG.levelHpBonus;
+    player.atk += RPG_CONFIG.levelAtkBonus;
+    player.def += RPG_CONFIG.levelDefBonus;
+    const healAmount = Math.ceil(player.maxHp * RPG_CONFIG.healOnLevelUpRatio);
+    player.hp = Math.min(player.maxHp, player.hp + healAmount);
+    healed += healAmount;
+    levelUps.push({ level: player.level });
+    resolution.messages.push('레벨 업! 능력이 향상되었습니다.');
+    xpNeeded = xpForNextLevel(player.level);
+  }
+  return { healed: healed, levelUps: levelUps };
+}
+
+function xpForNextLevel(level) {
+  return RPG_CONFIG.xpBase + (level - 1) * RPG_CONFIG.xpGrowth;
+}
+
+function applyFlags(state, flags) {
+  state.flags = state.flags || [];
+  if (Array.isArray(flags.add)) {
+    flags.add.forEach(function (flag) {
+      if (state.flags.indexOf(flag) === -1) state.flags.push(flag);
+    });
+  }
+  if (Array.isArray(flags.remove)) {
+    flags.remove.forEach(function (flag) {
+      const idx = state.flags.indexOf(flag);
+      if (idx !== -1) state.flags.splice(idx, 1);
+    });
+  }
+}
+
+function enqueueNextEvents(state, entries) {
+  if (!Array.isArray(entries) || !entries.length) return;
+  state.queue = state.queue || [];
+  entries.forEach(function (entry) {
+    if (entry && entry.eventId) {
+      if (entry.priority) {
+        state.queue.unshift(entry.eventId);
+      } else {
+        state.queue.push(entry.eventId);
+      }
+    }
+  });
+  if (state.queue.length > RPG_CONFIG.queueMax) {
+    state.queue = state.queue.slice(0, RPG_CONFIG.queueMax);
+  }
+}
+
+function drawNextEvent(player, state, context) {
+  state.queue = state.queue || [];
+  while (state.queue.length) {
+    const candidate = state.queue.shift();
+    const exists = getEventById(context.events, candidate);
+    if (exists) {
+      return exists.eventId;
+    }
+  }
+  return pickWeightedEvent(player, state, context);
+}
+
+function pickWeightedEvent(player, state, context) {
+  const events = context.events;
+  const weightShift = state.weightShift || {};
+  const tagsBoost = state.tagsBoost || {};
+  let total = 0;
+  const weighted = events.map(function (event) {
+    let weight = event.weight || 1;
+    event.tags.forEach(function (tag) {
+      if (state.flags && state.flags.indexOf('met_merchant') !== -1 && tag === 'town') {
+        weight *= 1.4;
+      }
+      if (tagsBoost[tag]) {
+        weight *= tagsBoost[tag];
+      }
+      if (weightShift[tag]) {
+        weight *= weightShift[tag];
+      }
+      if (tag === 'combat') {
+        weight *= Math.min(3, 0.7 + player.level * 0.4);
+      }
+      if (tag === 'rare') {
+        weight *= 0.8;
+      }
+    });
+    if (state.lastChoice && state.lastChoice.eventId === event.eventId) {
+      weight *= 0.35;
+    }
+    total += weight;
+    return { event: event, weight: weight };
+  });
+  if (total <= 0) {
+    return events[0] ? events[0].eventId : null;
+  }
+  const roll = pseudoRandom(player.seed + player.playerId + new Date().getMilliseconds()) * total;
+  let acc = 0;
+  for (var i = 0; i < weighted.length; i++) {
+    acc += weighted[i].weight;
+    if (roll <= acc) {
+      return weighted[i].event.eventId;
+    }
+  }
+  return weighted[weighted.length - 1].event.eventId;
+}
+
+function savePlayerState(player, state, context) {
+  const playersSheet = context.ss.getSheetByName(SHEET_NAMES.players);
+  if (!player.rowIndex) {
+    // If row index missing, locate row and retry.
+    const record = getCurrentPlayerRecord(context);
+    if (!record) return;
+    record.player.hp = player.hp;
+    record.player.maxHp = player.maxHp;
+    record.player.gold = player.gold;
+    record.player.atk = player.atk;
+    record.player.def = player.def;
+    record.player.level = player.level;
+    record.player.xp = player.xp;
+    record.player.lastPlayedAt = player.lastPlayedAt;
+    savePlayerState(record.player, state, context);
+    return;
+  }
+  const row = player.rowIndex;
+  const rowValues = [
+    player.playerId,
+    player.name,
+    player.cls,
+    player.hp,
+    player.maxHp,
+    player.gold,
+    player.atk,
+    player.def,
+    player.level,
+    player.xp,
+    player.seed,
+    player.createdAt,
+    player.lastPlayedAt,
+    JSON.stringify(state)
+  ];
+  playersSheet.getRange(row, 1, 1, rowValues.length).setValues([rowValues]);
+}
+
+function appendLogEntry(timestamp, playerId, eventId, choice, delta, resultText) {
+  const sheet = SpreadsheetApp.getActive().getSheetByName(SHEET_NAMES.log);
+  if (!sheet) return;
+  sheet.appendRow([
+    timestamp,
+    playerId,
+    eventId,
+    choice,
+    JSON.stringify(delta || {}),
+    resultText
+  ]);
+}
+
+function getRecentLogs(playerId, limit) {
+  const sheet = SpreadsheetApp.getActive().getSheetByName(SHEET_NAMES.log);
+  if (!sheet) return [];
+  const values = sheet.getDataRange().getValues();
+  values.shift();
+  const filtered = values.filter(function (row) { return row[1] === playerId; });
+  const recent = filtered.slice(-limit);
+  return recent.map(function (row) {
+    return {
+      timestamp: row[0],
+      eventId: row[2],
+      choice: row[3],
+      delta: parseJsonSafe(row[4]),
+      resultText: row[5]
+    };
+  });
+}
+
+// ------------------------------ NOTES ---------------------------------------
+// i18n 확장 포인트: Assets 시트에 text_* 키를 언어별로 저장한 뒤, loadGame에서 사용자 환경에 맞는 문자열로 교체하도록 로직을 확장할 수 있습니다.
+// 이벤트 추가 규칙: buildSampleEvents 주석 참고. 새로운 이벤트는 JSON 직렬화 규칙을 지키고, 확률 기반 결과는 rolls 배열로 설정합니다.

--- a/client.js
+++ b/client.js
@@ -1,0 +1,332 @@
+<script>
+/**
+ * client.js - Front-end logic for Hapoom RPG Sidebar.
+ * Handles UI binding, keyboard input (1/2/3), toast feedback, and server communication.
+ */
+(function () {
+  const state = {
+    loading: false,
+    selectedClass: null,
+    player: null,
+    gameState: null,
+    currentEvent: null,
+    debug: { isAdmin: false }
+  };
+
+  const els = {
+    hud: document.getElementById('hud'),
+    hudPortrait: document.getElementById('hud-portrait'),
+    hudName: document.getElementById('hud-name'),
+    hudHp: document.getElementById('hud-hp'),
+    hudGold: document.getElementById('hud-gold'),
+    hudXp: document.getElementById('hud-xp'),
+    hudLevel: document.getElementById('hud-level'),
+    creation: document.getElementById('creation'),
+    classGrid: document.getElementById('class-grid'),
+    btnCreate: document.getElementById('btn-create'),
+    inputName: document.getElementById('input-name'),
+    gameplay: document.getElementById('gameplay'),
+    choices: Array.from(document.querySelectorAll('.pixel-btn.choice')),
+    eventIcon: document.getElementById('event-icon'),
+    eventTitle: document.getElementById('event-title'),
+    eventDesc: document.getElementById('event-desc'),
+    queueCount: document.getElementById('queue-count'),
+    logTail: document.getElementById('log-tail'),
+    toast: document.getElementById('result-toast'),
+    debugPanel: document.getElementById('debug-panel'),
+    debugEvent: document.getElementById('debug-event'),
+    btnForceEvent: document.getElementById('btn-force-event'),
+    btnHeal: document.getElementById('btn-heal'),
+    loading: document.getElementById('loading')
+  };
+
+  function setLoading(flag) {
+    state.loading = flag;
+    els.loading.hidden = !flag;
+    els.choices.forEach(btn => btn.disabled = flag);
+    if (els.btnCreate) els.btnCreate.disabled = flag;
+  }
+
+  function showToast(message) {
+    els.toast.textContent = message;
+    els.toast.hidden = false;
+    setTimeout(() => {
+      els.toast.hidden = true;
+    }, 2000);
+  }
+
+  function renderCreation(payload) {
+    els.creation.hidden = false;
+    els.gameplay.hidden = true;
+    els.hud.hidden = true;
+    els.debugPanel.hidden = true;
+    els.classGrid.innerHTML = '';
+    state.selectedClass = null;
+    (payload.classes || []).forEach(cls => {
+      const card = document.createElement('div');
+      card.className = 'class-card';
+      card.dataset.key = cls.key;
+      card.innerHTML = `
+        <div class="class-name">${cls.name}</div>
+        <div class="class-desc">${cls.desc}</div>
+        <div class="class-stats">HP ${cls.hp} | ATK ${cls.atk} | DEF ${cls.def}</div>
+      `;
+      card.addEventListener('click', () => selectClass(cls.key, card));
+      els.classGrid.appendChild(card);
+    });
+    els.btnCreate.onclick = () => {
+      if (!state.selectedClass) {
+        showToast('직업을 선택해주세요.');
+        return;
+      }
+      const name = els.inputName.value.trim();
+      if (!name) {
+        showToast('이름을 입력해주세요.');
+        els.inputName.focus();
+        return;
+      }
+      setLoading(true);
+      google.script.run
+        .withSuccessHandler(data => {
+          setLoading(false);
+          bootstrapGame(data);
+          showToast('새로운 모험이 시작되었습니다!');
+        })
+        .withFailureHandler(err => {
+          setLoading(false);
+          showToast(err && err.message ? err.message : '생성 실패');
+        })
+        .startNewPlayer({ name, clsKey: state.selectedClass });
+    };
+  }
+
+  function selectClass(key, cardEl) {
+    state.selectedClass = key;
+    Array.from(els.classGrid.children).forEach(el => el.classList.remove('selected'));
+    cardEl.classList.add('selected');
+  }
+
+  function renderHUD(player) {
+    els.hud.hidden = false;
+    els.hudName.textContent = `${player.name} · ${player.cls}`;
+    els.hudHp.innerHTML = `<strong>HP</strong> ${player.hp}/${player.maxHp}`;
+    els.hudGold.innerHTML = `<strong>G</strong> ${player.gold}`;
+    els.hudXp.innerHTML = `<strong>XP</strong> ${player.xp}`;
+    els.hudLevel.innerHTML = `<strong>Lv.</strong> ${player.level}`;
+    els.hudPortrait.innerHTML = '<div class="px-sprite hero"></div>';
+  }
+
+  function renderEvent(event, queueSize) {
+    if (!event) {
+      els.eventTitle.textContent = '모험 종료';
+      els.eventDesc.textContent = '새로운 여행을 시작하세요.';
+      els.eventIcon.innerHTML = '<div class="px-sprite mystic"></div>';
+      els.choices.forEach(btn => {
+        btn.dataset.choice = 'RESET';
+        btn.textContent = '새로운 모험 시작';
+        btn.disabled = false;
+      });
+      return;
+    }
+    state.currentEvent = event;
+    els.eventTitle.textContent = event.title;
+    els.eventDesc.textContent = event.desc;
+    els.eventIcon.innerHTML = getEventIcon(event.tags);
+    const texts = {
+      A: event.choices.A.text,
+      B: event.choices.B.text,
+      C: event.choices.C.text
+    };
+    ['A','B','C'].forEach((key, idx) => {
+      const btn = els.choices[idx];
+      btn.dataset.choice = key;
+      btn.textContent = `${key}. ${texts[key]}`;
+      btn.disabled = false;
+    });
+    els.queueCount.textContent = queueSize;
+  }
+
+  function renderLogs(logs) {
+    if (!logs || !logs.length) {
+      els.logTail.innerHTML = '<div class="log-row">최근 로그 없음</div>';
+      return;
+    }
+    els.logTail.innerHTML = logs.map(entry => {
+      const time = formatTime(entry.timestamp);
+      const deltaText = formatDelta(entry.delta);
+      return `<div class="log-row"><span class="log-time">${time}</span> · ${entry.resultText} ${deltaText}</div>`;
+    }).join('');
+  }
+
+  function formatTime(ts) {
+    if (!ts) return '';
+    try {
+      const date = new Date(ts);
+      return `${date.getHours()}:${String(date.getMinutes()).padStart(2, '0')}`;
+    } catch (e) {
+      return '';
+    }
+  }
+
+  function formatDelta(delta) {
+    if (!delta) return '';
+    const parts = [];
+    Object.keys(delta).forEach(key => {
+      const val = delta[key];
+      if (typeof val === 'number' && val !== 0) {
+        const sign = val > 0 ? '+' : '';
+        parts.push(`${key.toUpperCase()} ${sign}${val}`);
+      }
+    });
+    return parts.length ? `<span class="delta">(${parts.join(', ')})</span>` : '';
+  }
+
+  function getEventIcon(tags) {
+    tags = tags || [];
+    if (tags.includes('combat')) {
+      return '<div class="px-sprite slime"></div>';
+    }
+    if (tags.includes('town')) {
+      return '<div class="px-sprite treasure"></div>';
+    }
+    if (tags.includes('mystic')) {
+      return '<div class="px-sprite mystic"></div>';
+    }
+    return '<div class="px-sprite hero"></div>';
+  }
+
+  function bindChoices() {
+    els.choices.forEach(btn => {
+      btn.addEventListener('click', () => submitChoice(btn.dataset.choice));
+    });
+  }
+
+  function submitChoice(choice) {
+    if (state.loading) return;
+    if (choice === 'RESET') {
+      setLoading(true);
+      google.script.run
+        .withSuccessHandler(data => {
+          setLoading(false);
+          bootstrapGame(data);
+          showToast('새로운 캐릭터를 생성하세요.');
+        })
+        .withFailureHandler(err => {
+          setLoading(false);
+          showToast(err && err.message ? err.message : '세션 초기화 실패');
+        })
+        .resetPlayerSession();
+      return;
+    }
+    setLoading(true);
+    google.script.run
+      .withSuccessHandler(data => {
+        setLoading(false);
+        bootstrapGame(data);
+        const { result } = data;
+        if (result) {
+          result.messages.forEach(message => showToast(message));
+          if (result.levelUps && result.levelUps.length) {
+            showToast(`레벨 ${result.levelUps.map(l => l.level).join(', ')} 달성!`);
+          }
+          if (result.death) {
+            showToast('패배했습니다. 캐릭터를 재생성하세요.');
+          }
+        }
+      })
+      .withFailureHandler(err => {
+        setLoading(false);
+        showToast(err && err.message ? err.message : '선택 처리 실패');
+      })
+      .chooseOption({ choice });
+  }
+
+  function bootstrapGame(data) {
+    if (!data) return;
+    state.debug = data.debug || { isAdmin: false };
+    if (data.needsCreation) {
+      renderCreation(data);
+      return;
+    }
+    state.player = data.player;
+    state.gameState = data.state;
+    renderHUD(data.player);
+    renderEvent(data.event, data.queueSize);
+    renderLogs(data.logs);
+    els.creation.hidden = true;
+    els.gameplay.hidden = false;
+    els.hud.hidden = false;
+    els.debugPanel.hidden = !state.debug.isAdmin;
+  }
+
+  function bindKeyboard() {
+    document.addEventListener('keydown', evt => {
+      if (state.loading) return;
+      if (['INPUT', 'TEXTAREA'].includes(evt.target.tagName)) return;
+      if (evt.key === '1') {
+        evt.preventDefault();
+        submitChoice('A');
+      } else if (evt.key === '2') {
+        evt.preventDefault();
+        submitChoice('B');
+      } else if (evt.key === '3') {
+        evt.preventDefault();
+        submitChoice('C');
+      }
+    });
+  }
+
+  function bindDebug() {
+    els.btnForceEvent.addEventListener('click', () => {
+      const eventId = els.debugEvent.value.trim();
+      if (!eventId) return;
+      setLoading(true);
+      google.script.run
+        .withSuccessHandler(data => {
+          setLoading(false);
+          bootstrapGame(data);
+          showToast('이벤트가 큐에 추가되었습니다.');
+        })
+        .withFailureHandler(err => {
+          setLoading(false);
+          showToast(err && err.message ? err.message : '디버그 실패');
+        })
+        .toggleDebugAction('forceEvent', eventId);
+    });
+    els.btnHeal.addEventListener('click', () => {
+      setLoading(true);
+      google.script.run
+        .withSuccessHandler(data => {
+          setLoading(false);
+          bootstrapGame(data);
+          showToast('체력을 회복했습니다.');
+        })
+        .withFailureHandler(err => {
+          setLoading(false);
+          showToast(err && err.message ? err.message : '디버그 실패');
+        })
+        .toggleDebugAction('heal', true);
+    });
+  }
+
+  function init() {
+    bindChoices();
+    bindKeyboard();
+    bindDebug();
+    setLoading(true);
+    google.script.run
+      .withSuccessHandler(data => {
+        setLoading(false);
+        bootstrapGame(data);
+        els.inputName && els.inputName.focus();
+      })
+      .withFailureHandler(err => {
+        setLoading(false);
+        showToast(err && err.message ? err.message : '로딩 실패');
+      })
+      .loadGame();
+  }
+
+  document.addEventListener('DOMContentLoaded', init);
+})();
+</script>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,399 @@
+<style>
+/*
+  styles.css - Pixel-inspired neon/pastel palette for Hapoom RPG UI.
+  Utilizes pure CSS to render sprites, cards, buttons, and interactive feedback.
+*/
+:root {
+  --pal-bg: #0d0f1a;
+  --pal-accent: #7DF9FF;
+  --pal-positive: #A7F3D0;
+  --pal-negative: #FCA5A5;
+  --pal-card: #15192b;
+  --pal-card-border: #1f2540;
+  --pal-text: #f0f6ff;
+  --pal-muted: #7c8bae;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body.hapoom-body {
+  background: var(--pal-bg);
+  color: var(--pal-text);
+  font-family: 'Segoe UI', 'Malgun Gothic', sans-serif;
+  margin: 0;
+  padding: 12px;
+  image-rendering: pixelated;
+}
+
+.app-shell {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-height: 100vh;
+}
+
+.hud {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  background: linear-gradient(135deg, rgba(125, 249, 255, 0.1), rgba(12, 15, 32, 0.9));
+  border: 2px solid var(--pal-card-border);
+  border-radius: 8px;
+  padding: 12px;
+  box-shadow: 0 0 8px rgba(125, 249, 255, 0.2);
+}
+
+.hud-portrait {
+  width: 64px;
+  height: 64px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.hud-info {
+  flex: 1;
+}
+
+.hud-name {
+  font-size: 18px;
+  letter-spacing: 1px;
+}
+
+.hud-stats {
+  display: flex;
+  gap: 8px;
+  font-size: 12px;
+  color: var(--pal-muted);
+}
+
+.stat strong {
+  color: var(--pal-accent);
+}
+
+.panel {
+  background: var(--pal-card);
+  border: 2px solid var(--pal-card-border);
+  border-radius: 10px;
+  padding: 16px;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05), 0 6px 18px rgba(0, 0, 0, 0.3);
+  position: relative;
+}
+
+.panel-title {
+  font-size: 14px;
+  text-transform: uppercase;
+  color: var(--pal-accent);
+  margin-bottom: 12px;
+}
+
+.panel-content {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.field.inline {
+  flex-direction: row;
+  align-items: center;
+}
+
+.field input[type="text"] {
+  background: rgba(15, 19, 38, 0.95);
+  border: 2px solid var(--pal-card-border);
+  border-radius: 8px;
+  padding: 8px 10px;
+  color: var(--pal-text);
+  font-size: 14px;
+  outline: none;
+}
+
+.class-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+  gap: 10px;
+}
+
+.class-card {
+  border: 2px solid var(--pal-card-border);
+  border-radius: 8px;
+  padding: 10px;
+  cursor: pointer;
+  background: rgba(16, 20, 38, 0.9);
+  transition: transform 0.1s ease;
+}
+
+.class-card.selected {
+  border-color: var(--pal-accent);
+  box-shadow: 0 0 8px rgba(125, 249, 255, 0.4);
+  transform: translateY(-2px);
+}
+
+.class-card:hover {
+  border-color: var(--pal-accent);
+}
+
+.class-card .class-name {
+  font-size: 14px;
+  color: var(--pal-accent);
+}
+
+.class-card .class-desc {
+  font-size: 12px;
+  color: var(--pal-muted);
+}
+
+.pixel-btn {
+  position: relative;
+  border: none;
+  border-radius: 8px;
+  padding: 10px 14px;
+  background: linear-gradient(180deg, rgba(125, 249, 255, 0.6), rgba(125, 249, 255, 0.2));
+  color: var(--pal-text);
+  font-weight: bold;
+  letter-spacing: 1px;
+  cursor: pointer;
+  transition: transform 0.06s ease, box-shadow 0.1s;
+}
+
+.pixel-btn.primary {
+  background: linear-gradient(180deg, rgba(167, 243, 208, 0.7), rgba(31, 41, 55, 0.8));
+  color: #122223;
+}
+
+.pixel-btn:before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: 8px;
+  border: 2px solid rgba(255, 255, 255, 0.15);
+  pointer-events: none;
+}
+
+.pixel-btn:hover {
+  box-shadow: 0 0 6px rgba(125, 249, 255, 0.5);
+  transform: translateY(-1px);
+}
+
+.pixel-btn:active {
+  transform: translateY(2px);
+  box-shadow: inset 0 2px 0 rgba(255, 255, 255, 0.2);
+}
+
+.pixel-btn.choice {
+  width: 100%;
+  text-align: left;
+  margin-bottom: 10px;
+  font-size: 14px;
+}
+
+.event-card {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.event-icon {
+  width: 96px;
+  height: 96px;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.event-header {
+  text-align: center;
+}
+
+.event-title {
+  font-size: 16px;
+  color: var(--pal-accent);
+  margin-bottom: 6px;
+}
+
+.event-desc {
+  font-size: 13px;
+  color: var(--pal-text);
+  line-height: 1.4;
+}
+
+.event-footer {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.queue-indicator {
+  font-size: 12px;
+  color: var(--pal-muted);
+}
+
+.log-tail {
+  font-size: 11px;
+  color: rgba(240, 246, 255, 0.8);
+  background: rgba(11, 14, 30, 0.7);
+  border-radius: 6px;
+  padding: 8px;
+  max-height: 120px;
+  overflow-y: auto;
+  border: 1px solid rgba(125, 249, 255, 0.15);
+}
+
+.toast {
+  position: fixed;
+  bottom: 20px;
+  left: 20px;
+  right: 20px;
+  padding: 12px 16px;
+  border-radius: 8px;
+  border: 2px solid var(--pal-card-border);
+  background: rgba(9, 12, 26, 0.95);
+  color: var(--pal-text);
+  font-size: 13px;
+  box-shadow: 0 0 12px rgba(125, 249, 255, 0.3);
+  animation: toast-pop 0.3s ease;
+}
+
+@keyframes toast-pop {
+  from { transform: translateY(12px); opacity: 0; }
+  to { transform: translateY(0); opacity: 1; }
+}
+
+.loading-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(5, 6, 14, 0.65);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  backdrop-filter: blur(2px);
+}
+
+.spinner {
+  width: 32px;
+  height: 32px;
+  border: 4px solid rgba(125, 249, 255, 0.2);
+  border-top-color: var(--pal-accent);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  from { transform: rotate(0); }
+  to { transform: rotate(360deg); }
+}
+
+/* Simple CSS pixel sprites */
+.px-sprite {
+  position: relative;
+  width: 48px;
+  height: 48px;
+  image-rendering: pixelated;
+}
+
+.px-sprite:before,
+.px-sprite:after {
+  content: '';
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  background-repeat: no-repeat;
+  background-size: contain;
+}
+
+/* Hero sprite using gradient blocks */
+.px-sprite.hero {
+  background: none;
+}
+
+.px-sprite.hero:before {
+  box-shadow:
+    16px 4px 0 0 #243148,
+    20px 4px 0 0 #243148,
+    24px 4px 0 0 #243148,
+    12px 8px 0 0 #3a4d6f,
+    16px 8px 0 0 #7DF9FF,
+    20px 8px 0 0 #7DF9FF,
+    24px 8px 0 0 #3a4d6f,
+    12px 12px 0 0 #3a4d6f,
+    16px 12px 0 0 #A7F3D0,
+    20px 12px 0 0 #A7F3D0,
+    24px 12px 0 0 #3a4d6f,
+    12px 16px 0 0 #2b3a54,
+    16px 16px 0 0 #fffbf5,
+    20px 16px 0 0 #fffbf5,
+    24px 16px 0 0 #2b3a54,
+    12px 20px 0 0 #2b3a54,
+    16px 20px 0 0 #243148,
+    20px 20px 0 0 #243148,
+    24px 20px 0 0 #2b3a54,
+    12px 24px 0 0 #1a2435,
+    16px 24px 0 0 #1a2435,
+    20px 24px 0 0 #1a2435,
+    24px 24px 0 0 #1a2435;
+}
+
+.px-sprite.slime:before {
+  box-shadow:
+    10px 22px 0 0 rgba(125, 249, 255, 0.9),
+    14px 18px 0 0 rgba(125, 249, 255, 0.7),
+    18px 16px 0 0 rgba(167, 243, 208, 0.7),
+    22px 18px 0 0 rgba(125, 249, 255, 0.8),
+    26px 22px 0 0 rgba(125, 249, 255, 0.5),
+    18px 26px 0 0 rgba(125, 249, 255, 0.9),
+    22px 26px 0 0 rgba(125, 249, 255, 0.9);
+}
+
+.px-sprite.treasure:before {
+  box-shadow:
+    12px 16px 0 0 #8d6b3a,
+    16px 16px 0 0 #dba34b,
+    20px 16px 0 0 #dba34b,
+    24px 16px 0 0 #8d6b3a,
+    12px 20px 0 0 #fcd34d,
+    16px 20px 0 0 #fde68a,
+    20px 20px 0 0 #fde68a,
+    24px 20px 0 0 #fcd34d,
+    12px 24px 0 0 #8d6b3a,
+    16px 24px 0 0 #dba34b,
+    20px 24px 0 0 #dba34b,
+    24px 24px 0 0 #8d6b3a;
+}
+
+.px-sprite.mystic:before {
+  box-shadow:
+    12px 12px 0 0 rgba(125, 249, 255, 0.7),
+    16px 8px 0 0 rgba(167, 243, 208, 0.6),
+    20px 12px 0 0 rgba(125, 249, 255, 0.8),
+    16px 16px 0 0 rgba(125, 249, 255, 0.6),
+    20px 20px 0 0 rgba(167, 243, 208, 0.5);
+}
+
+#event-icon .px-sprite {
+  transform: scale(1.4);
+}
+
+.panel-debug {
+  border-style: dashed;
+  border-color: rgba(125, 249, 255, 0.5);
+  background: rgba(19, 23, 42, 0.85);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pixel-btn,
+  .spinner {
+    animation-duration: 1.5s !important;
+    transition-duration: 0 !important;
+  }
+}
+</style>

--- a/ui.html
+++ b/ui.html
@@ -1,0 +1,83 @@
+<!--
+  ui.html - Root HTML template for Hapoom RPG Sidebar UI.
+  Provides layout containers for creation view, gameplay view, HUD, logs, and debug controls.
+-->
+<!DOCTYPE html>
+<html>
+  <head>
+    <base target="_top">
+    <?!= HtmlService.createHtmlOutputFromFile('styles.css').getContent(); ?>
+  </head>
+  <body class="hapoom-body">
+    <div id="app" class="app-shell">
+      <div class="hud" id="hud" hidden>
+        <div class="hud-portrait" id="hud-portrait"></div>
+        <div class="hud-info">
+          <div class="hud-name" id="hud-name"></div>
+          <div class="hud-stats">
+            <span class="stat" id="hud-hp"></span>
+            <span class="stat" id="hud-gold"></span>
+            <span class="stat" id="hud-xp"></span>
+            <span class="stat" id="hud-level"></span>
+          </div>
+        </div>
+      </div>
+
+      <section id="creation" class="panel panel-creation" hidden>
+        <div class="panel-title">새로운 모험가</div>
+        <div class="panel-content">
+          <label class="field">
+            <span>이름</span>
+            <input type="text" id="input-name" maxlength="18" placeholder="네온빛 이름" autofocus>
+          </label>
+          <div class="class-grid" id="class-grid"></div>
+          <button id="btn-create" class="pixel-btn primary">모험 시작</button>
+        </div>
+      </section>
+
+      <section id="gameplay" class="panel panel-event" hidden>
+        <div class="event-card">
+          <div class="event-icon" id="event-icon"></div>
+          <div class="event-header">
+            <div class="event-title" id="event-title"></div>
+            <div class="event-desc" id="event-desc"></div>
+          </div>
+          <div class="event-choices">
+            <button class="pixel-btn choice" data-choice="A" id="choice-A"></button>
+            <button class="pixel-btn choice" data-choice="B" id="choice-B"></button>
+            <button class="pixel-btn choice" data-choice="C" id="choice-C"></button>
+          </div>
+        </div>
+        <div class="event-footer">
+          <div class="queue-indicator">다음 카드: <span id="queue-count">0</span></div>
+          <div class="log-tail" id="log-tail"></div>
+        </div>
+      </section>
+
+      <section id="result-toast" class="toast" hidden></section>
+
+      <section id="debug-panel" class="panel panel-debug" hidden>
+        <div class="panel-title">디버그</div>
+        <div class="panel-content">
+          <div class="field">
+            <label for="debug-event">이벤트 강제</label>
+            <input type="text" id="debug-event" placeholder="이벤트 ID">
+            <button class="pixel-btn" id="btn-force-event">큐에 추가</button>
+          </div>
+          <div class="field inline">
+            <button class="pixel-btn" id="btn-heal">HP 회복</button>
+          </div>
+        </div>
+      </section>
+
+      <div id="loading" class="loading-overlay" hidden>
+        <div class="spinner"></div>
+      </div>
+    </div>
+
+    <script>
+      const BOOTSTRAP = { version: <?= data.version ?> };
+    </script>
+    <?!= HtmlService.createHtmlOutputFromFile('client.js').getContent(); ?>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add Apps Script backend that initializes required sheets, seeds sample events and assets, and drives the RPG game loop with logging, leveling, and debug tools.
- build HTML sidebar layout with HUD, event card, creation form, loading overlay, and debug panel styled for a neon pixel aesthetic.
- implement client-side logic for character creation, choice handling with keyboard shortcuts, death resets, and Google Apps Script communication hooks.

## Testing
- not run (Apps Script environment)


------
https://chatgpt.com/codex/tasks/task_e_68e293861e4c8327b3d8b4a3169d1802